### PR TITLE
Basic S3 Integration & Endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,11 @@ The following request will embed a TXT document with OpenAI's ADA model and uplo
 curl -X POST -H 'Content-Type: multipart/form-data' -H "Authorization: INTERNAL_API_KEY" -H "X-EmbeddingAPI-Key: your-key-here" -H "X-VectorDB-Key: your-key-here" -F 'EmbeddingsMetadata={"embeddings_type": "open_ai", "chunk_size": 256, "chunk_overlap": 128}' -F 'SourceData=@./src/api/tests/fixtures/test_text.txt' -F 'VectorDBMetadata={"vector_db_type": "pinecone", "index_name": "test", "environment": "us-east-1-aws"}'  http://localhost:8000/embed
 ```
 
+To check the status of the job, 
+```
+curl -X GET -H "Authorization: INTERNAL_API_KEY" http://localhost:8000/jobs/<job_id>/status
+```
+
 # Contributing
 
 We love feedback from the community. If you have an idea of how to make this project better, we encourage you to open an issue or join our Discord. Please tag `dgarnitz` and `danmeier2`.

--- a/src/api/Dockerfile
+++ b/src/api/Dockerfile
@@ -8,7 +8,9 @@ ENV PYTHONUNBUFFERED=1
 WORKDIR /app
 
 # Install system dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends gcc
+RUN apt-get update && apt-get install -y --no-install-recommends gcc  && apt-get install -y libmagic1 \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 
 # Copy key requirements
 COPY api /app/api

--- a/src/api/app.py
+++ b/src/api/app.py
@@ -4,6 +4,8 @@ import os
 # this is needed to import classes from other modules
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../')))
 
+import requests
+import magic
 import json
 import fitz
 from io import BytesIO
@@ -11,15 +13,11 @@ import services.database.batch_service as batch_service
 import services.database.job_service as job_service
 from flask import Flask, request, jsonify
 from flask_cors import CORS
-from models.embeddings_metadata import EmbeddingsMetadata
-from models.vector_db_metadata import VectorDBMetadata
 from models.batch import Batch
 from api.auth import Auth
 from api.pipeline import Pipeline
-from shared.job_status import JobStatus
 from services.database.database import get_db
-from shared.embeddings_type import EmbeddingsType
-from shared.vector_db_type import VectorDBType
+from api.vectorflow_request import VectorflowRequest
 
 auth = Auth()
 pipeline = Pipeline()
@@ -28,29 +26,11 @@ CORS(app)
 
 @app.route("/embed", methods=['POST'])
 def embed():
-    vectorflow_key = request.headers.get('Authorization')
-    if not vectorflow_key or not auth.validate_credentials(vectorflow_key):
+    vectorflow_request = VectorflowRequest(request)
+    if not vectorflow_request.vectorflow_key or not auth.validate_credentials(vectorflow_request.vectorflow_key):
         return jsonify({'error': 'Invalid credentials'}), 401
-    
-    vector_db_key = request.headers.get('X-VectorDB-Key')
-    embedding_api_key = request.headers.get('X-EmbeddingAPI-Key')
-    
-    webhook_url = request.form.get('WebhookURL')
-    embeddings_metadata_dict = json.loads(request.form.get('EmbeddingsMetadata'))
-    embeddings_metadata = EmbeddingsMetadata(
-        embeddings_type = EmbeddingsType(embeddings_metadata_dict['embeddings_type']), 
-        chunk_size = embeddings_metadata_dict['chunk_size'],
-        chunk_overlap = embeddings_metadata_dict['chunk_overlap'])
-    
-    vector_db_metadata_dict = json.loads(request.form.get('VectorDBMetadata'))
-    vector_db_metadata = VectorDBMetadata(
-        vector_db_type = VectorDBType(vector_db_metadata_dict['vector_db_type']), 
-        index_name = vector_db_metadata_dict['index_name'], 
-        environment = vector_db_metadata_dict['environment'])
-    
-    lines_per_batch = int(request.form.get('LinesPerBatch')) if request.form.get('LinesPerBatch') else 1000
  
-    if not embeddings_metadata or not vector_db_metadata:
+    if not vectorflow_request.embeddings_metadata or not vectorflow_request.vector_db_metadata or not vectorflow_request.vector_db_key:
         return jsonify({'error': 'Missing required fields'}), 400
     
     if 'SourceData' not in request.files:
@@ -62,27 +42,15 @@ def embed():
     if file.filename == '':
         return jsonify({'message': 'No selected file'}), 400
     
-    # Check if the file has a .txt extension
     if file and (file.filename.endswith('.txt') or file.filename.endswith('.pdf')):
-        if file.filename.endswith('.txt'):
-            file_content = file.read().decode('utf-8')
-        else:
-            pdf_data = BytesIO(file.read())
-            with fitz.open(stream=pdf_data, filetype='pdf') as doc:
-                file_content = ""
-                for page in doc:
-                    file_content += page.get_text()
-
-        with get_db() as db:
-            job = job_service.create_job(db, webhook_url)
-        batch_count = create_batches(file_content, job.id, embeddings_metadata, vector_db_metadata, lines_per_batch, vector_db_key, embedding_api_key)
-        return jsonify({'message': f"Successfully added {batch_count} batches to the queue", 'JobID': job.id}), 200
+        batch_count, job_id = process_file(file, vectorflow_request)
+        return jsonify({'message': f"Successfully added {batch_count} batches to the queue", 'JobID': job_id}), 200
     else:
-        return jsonify({'message': 'Uploaded file is not a TXT file'}), 400
+        return jsonify({'message': 'Uploaded file is not a TXT or PDF file'}), 400
 
 @app.route('/jobs/<int:job_id>/status', methods=['GET'])
 def get_job_status(job_id):
-    vectorflow_key = request.headers.get('VectorFlowKey')
+    vectorflow_key = request.headers.get('Authorization')
     if not vectorflow_key or not auth.validate_credentials(vectorflow_key):
         return jsonify({'error': 'Invalid credentials'}), 401
     
@@ -97,7 +65,7 @@ def get_job_status(job_id):
 #: NOTE: This endpoint is for debugging and testing only. 
 @app.route("/dequeue")
 def dequeue():
-    vectorflow_key = request.headers.get('VectorFlowKey')
+    vectorflow_key = request.headers.get('Authorization')
     if not vectorflow_key or not auth.validate_credentials(vectorflow_key):
         return jsonify({'error': 'Invalid credentials'}), 401
     
@@ -113,17 +81,71 @@ def dequeue():
         batch_id, source_data = data
 
         return jsonify({'batch_id': batch_id, 'source_data': source_data}), 200
+    
+@app.route("/s3", methods=['POST'])
+def s3_presigned_url():
+    vectorflow_request = VectorflowRequest(request)
+    if not vectorflow_request.vectorflow_key or not auth.validate_credentials(vectorflow_request.vectorflow_key):
+        return jsonify({'error': 'Invalid credentials'}), 401
+ 
+    pre_signed_url = request.form.get('PreSignedURL')
+    if not vectorflow_request.embeddings_metadata or not vectorflow_request.vector_db_metadata or not vectorflow_request.vector_db_key or not pre_signed_url:
+        return jsonify({'error': 'Missing required fields'}), 400
+    
+    response = requests.get(pre_signed_url)
+    if response.status_code == 200:
+        file_magic = magic.Magic(mime=True)
+        mime_type = file_magic.from_buffer(response.content)
 
-def create_batches(file_content, job_id, embeddings_metadata, vector_db_metadata, lines_per_chunk, vector_db_key, embedding_api_key):
-    chunks = [chunk for chunk in split_file(file_content, lines_per_chunk)]
+        if mime_type == 'text/plain':
+            file_content = response.text
+            with get_db() as db:
+                job = job_service.create_job(db, vectorflow_request.webhook_url)
+            batch_count = create_batches(file_content, job.id, vectorflow_request)
+            return jsonify({'message': f"Successfully added {batch_count} batches to the queue", 'JobID': job.id}), 200
+        
+        elif mime_type == 'application/pdf':
+            pdf_data = BytesIO(response.content)
+            with fitz.open(stream=pdf_data, filetype='pdf') as doc:
+                file_content = ""
+                for page in doc:
+                    file_content += page.get_text()
+
+            with get_db() as db:
+                job = job_service.create_job(db, vectorflow_request.webhook_url)
+            batch_count = create_batches(file_content, job.id, vectorflow_request)
+            return jsonify({'message': f"Successfully added {batch_count} batches to the queue", 'JobID': job.id}), 200
+        
+        else:
+            return jsonify({'message': 'Uploaded file is not a TXT or PDF file'}), 400
+    else:
+        print('Failed to download file:', response.status_code, response.reason)
+
+def process_file(file, vectorflow_request):
+    if file.filename.endswith('.txt'):
+        file_content = file.read().decode('utf-8')
+    else:
+        pdf_data = BytesIO(file.read())
+        with fitz.open(stream=pdf_data, filetype='pdf') as doc:
+            file_content = ""
+            for page in doc:
+                file_content += page.get_text()
+
+    with get_db() as db:
+        job = job_service.create_job(db, vectorflow_request.webhook_url)
+    batch_count = create_batches(file_content, job.id, vectorflow_request)
+    return batch_count, job.id
+
+def create_batches(file_content, job_id, vectorflow_request):
+    chunks = [chunk for chunk in split_file(file_content, vectorflow_request.lines_per_batch)]
     
     with get_db() as db:
-        batches = [Batch(job_id=job_id, embeddings_metadata=embeddings_metadata, vector_db_metadata=vector_db_metadata) for _ in chunks]
+        batches = [Batch(job_id=job_id, embeddings_metadata=vectorflow_request.embeddings_metadata, vector_db_metadata=vectorflow_request.vector_db_metadata) for _ in chunks]
         batches = batch_service.create_batches(db, batches)
         job = job_service.update_job_total_batches(db, job_id, len(batches))
 
         for batch, chunk in zip(batches, chunks):
-            data = (batch.id, chunk, vector_db_key, embedding_api_key)
+            data = (batch.id, chunk, vectorflow_request.vector_db_key, vectorflow_request.embedding_api_key)
             json_data = json.dumps(data)
 
             pipeline.connect()

--- a/src/api/requirements.txt
+++ b/src/api/requirements.txt
@@ -1,3 +1,4 @@
+alembic==1.11.3
 argcomplete==3.1.1
 blinker==1.6.2
 boto3==1.28.27
@@ -17,6 +18,7 @@ itsdangerous==2.1.2
 Jinja2==3.1.2
 jmespath==1.0.1
 kappa==0.6.0
+Mako==1.2.4
 MarkupSafe==2.1.3
 packaging==23.1
 pika==1.3.2
@@ -24,6 +26,7 @@ placebo==0.9.0
 psycopg2-binary==2.9.6
 PyMuPDF==1.22.5
 python-dateutil==2.8.2
+python-magic==0.4.27
 python-slugify==8.0.1
 PyYAML==6.0.1
 requests==2.31.0

--- a/src/api/vectorflow_request.py
+++ b/src/api/vectorflow_request.py
@@ -1,0 +1,13 @@
+from models.embeddings_metadata import EmbeddingsMetadata
+from models.vector_db_metadata import VectorDBMetadata
+
+
+class VectorflowRequest:
+    def __init__(self, request):
+        self.vectorflow_key = request.headers.get('Authorization')
+        self.vector_db_key = request.headers.get('X-VectorDB-Key')
+        self.embedding_api_key = request.headers.get('X-EmbeddingAPI-Key')
+        self.webhook_url = request.form.get('WebhookURL')
+        self.vector_db_metadata = VectorDBMetadata._from_request(request)
+        self.embeddings_metadata = EmbeddingsMetadata._from_request(request)
+        self.lines_per_batch = int(request.form.get('LinesPerBatch')) if request.form.get('LinesPerBatch') else 1000

--- a/src/models/embeddings_metadata.py
+++ b/src/models/embeddings_metadata.py
@@ -1,3 +1,4 @@
+import json
 from sqlalchemy import Column, Integer, String, Enum
 from services.database.database import Base
 from shared.embeddings_type import EmbeddingsType
@@ -18,3 +19,12 @@ class EmbeddingsMetadata(Base):
             'chunk_overlap': self.chunk_overlap,
             'docker_image': self.docker_image,
         }
+    
+    @staticmethod
+    def _from_request(request):
+        embeddings_metadata_dict = json.loads(request.form.get('EmbeddingsMetadata'))
+        embeddings_metadata = EmbeddingsMetadata(
+            embeddings_type = EmbeddingsType(embeddings_metadata_dict['embeddings_type']), 
+            chunk_size = embeddings_metadata_dict['chunk_size'],
+            chunk_overlap = embeddings_metadata_dict['chunk_overlap'])
+        return embeddings_metadata

--- a/src/models/vector_db_metadata.py
+++ b/src/models/vector_db_metadata.py
@@ -1,3 +1,4 @@
+import json
 from services.database.database import Base
 from sqlalchemy import Column, Integer, String, Enum
 from shared.vector_db_type import VectorDBType
@@ -16,3 +17,12 @@ class VectorDBMetadata(Base):
             'index_name': self.index_name,
             'environment': self.environment,
         }
+    
+    @staticmethod
+    def _from_request(request):
+        vector_db_metadata_dict = json.loads(request.form.get('VectorDBMetadata'))
+        vector_db_metadata = VectorDBMetadata(
+            vector_db_type = VectorDBType(vector_db_metadata_dict['vector_db_type']), 
+            index_name = vector_db_metadata_dict['index_name'], 
+            environment = vector_db_metadata_dict['environment'])
+        return vector_db_metadata


### PR DESCRIPTION
## What
Added a new s3 ingestion endpoint, `/s3`, where a user can pass a presigned S3 URL and vectorflow will download and embed a single file from that URL. 

This uses HTTP not streaming. The next step in the process is to upgrade to this to allow for larger file uploads.

## Why
This is a key integration for making VectorFlow useful in production environments

## Verification
The following embeddings succeeded:

- presigned URL with txt
- presigned URL with pdf
- regressive test of /embed with a txt

Tests were confirmed using Qdrant running in Docker