### PR TITLE
Adding paragraph and sentence chunking strategy.

### DIFF
--- a/src/models/embeddings_metadata.py
+++ b/src/models/embeddings_metadata.py
@@ -2,6 +2,7 @@ import json
 from sqlalchemy import Column, Integer, String, Enum
 from services.database.database import Base
 from shared.embeddings_type import EmbeddingsType
+from shared.chunk_strategy import ChunkStrategy
 
 class EmbeddingsMetadata(Base):
     __tablename__ = 'embeddings_metadata'
@@ -10,6 +11,7 @@ class EmbeddingsMetadata(Base):
     embeddings_type = Column(Enum(EmbeddingsType))
     chunk_size = Column(Integer)
     chunk_overlap = Column(Integer)
+    chunk_strategy = Column(Enum(ChunkStrategy))
     docker_image = Column(String)
 
     def serialize(self):

--- a/src/models/embeddings_metadata.py
+++ b/src/models/embeddings_metadata.py
@@ -19,6 +19,7 @@ class EmbeddingsMetadata(Base):
             'embeddings_type': self.embeddings_type.name if self.embeddings_type else None,
             'chunk_size': self.chunk_size,
             'chunk_overlap': self.chunk_overlap,
+            'chunk_strategy': self.chunk_strategy,
             'docker_image': self.docker_image,
         }
     
@@ -28,5 +29,6 @@ class EmbeddingsMetadata(Base):
         embeddings_metadata = EmbeddingsMetadata(
             embeddings_type = EmbeddingsType[embeddings_metadata_dict['embeddings_type']], 
             chunk_size = embeddings_metadata_dict['chunk_size'],
-            chunk_overlap = embeddings_metadata_dict['chunk_overlap'])
+            chunk_overlap = embeddings_metadata_dict['chunk_overlap'],
+            chunk_strategy = embeddings_metadata_dict['chunk_strategy'])
         return embeddings_metadata

--- a/src/shared/chunk_strategy.py
+++ b/src/shared/chunk_strategy.py
@@ -1,0 +1,6 @@
+from enum import Enum
+
+class ChunkStrategy(Enum):
+    EXACT = 'exact'
+    PARAGRAPH = 'paragraph'
+    SENTENCE = 'sentence'

--- a/src/worker/tests/test_worker.py
+++ b/src/worker/tests/test_worker.py
@@ -141,6 +141,36 @@ class TestWorker(unittest.TestCase):
         self.assertEqual(upsert_list[0]['metadata']['source_text'], chunks[0])
         self.assertEqual(upsert_list[0]['values'], [1.0, 2.0, 3.0, 4.0, 5.0])
 
+    def test_chunk_paragraph(self):
+        data = ["This is an example paragraph.\n\n"] * 4
+        
+        chunks = worker.chunk_data_by_paragraph(data, chunk_size=35, over_lap=0)
+
+        self.assertEqual(len(chunks), 4)
+
+    def test_chunk_paragraph_over_lap(self):
+        data = ["This is an example paragraph.\n\n"] * 2
+
+        chunks = worker.chunk_data_by_paragraph(data, chunk_size=35, over_lap=15)
+
+        expected_overlap = 'This is an exam'
+        self.assertEqual(chunks[0][:15], expected_overlap)
+
+    def test_chunk_paragraph_bound(self):
+        data = ["This is \n\n a very early paragraph."]
+
+        chunks = worker.chunk_data_by_paragraph(data, chunk_size=35, over_lap=0, bound=0.75)
+
+        self.assertEqual(len(chunks), 1)
+
+    def test_chunk_sentence(self):
+        data = ["I am a sentence. I am a sentence but with a question? I am still a sentence! Can I consider myself a sentence..."]
+        
+        chunks = worker.chunk_by_sentence(data)
+
+        self.assertEqual(len(chunks), 4)
+
+
     def test_create_openai_batches(self):
         # arrange
         batches = ["test"] * config.MAX_OPENAI_EMBEDDING_BATCH_SIZE * 4

--- a/src/worker/tests/test_worker.py
+++ b/src/worker/tests/test_worker.py
@@ -144,14 +144,14 @@ class TestWorker(unittest.TestCase):
     def test_chunk_paragraph(self):
         data = ["This is an example paragraph.\n\n"] * 4
         
-        chunks = worker.chunk_data_by_paragraph(data, chunk_size=35, over_lap=0)
+        chunks = worker.chunk_data_by_paragraph(data, chunk_size=35, overlap=0)
 
         self.assertEqual(len(chunks), 4)
 
-    def test_chunk_paragraph_over_lap(self):
+    def test_chunk_paragraph_overlap(self):
         data = ["This is an example paragraph.\n\n"] * 2
 
-        chunks = worker.chunk_data_by_paragraph(data, chunk_size=35, over_lap=15)
+        chunks = worker.chunk_data_by_paragraph(data, chunk_size=35, overlap=15)
 
         expected_overlap = 'This is an exam'
         self.assertEqual(chunks[0][:15], expected_overlap)
@@ -159,7 +159,7 @@ class TestWorker(unittest.TestCase):
     def test_chunk_paragraph_bound(self):
         data = ["This is \n\n a very early paragraph."]
 
-        chunks = worker.chunk_data_by_paragraph(data, chunk_size=35, over_lap=0, bound=0.75)
+        chunks = worker.chunk_data_by_paragraph(data, chunk_size=35, overlap=0, bound=0.75)
 
         self.assertEqual(len(chunks), 1)
 

--- a/src/worker/worker.py
+++ b/src/worker/worker.py
@@ -78,9 +78,9 @@ def embed_openai_batch(batch, source_data):
 
     chunk_strategy = batch.embeddings_metadata.chunk_strategy
     
-    if chunk_strategy == ChunkStrategy.EXACT: 
+    if chunk_strategy == ChunkStrategy.EXACT:
         chunked_data = chunk_data(source_data, batch.embeddings_metadata.chunk_size, batch.embeddings_metadata.chunk_overlap)
-    
+
     if chunk_strategy == ChunkStrategy.PARAGRAPH:
         chunked_data = chunk_data_by_paragraph(source_data, batch.embeddings_metadata.chunk_size, batch.embeddings_metadata.chunk_overlap)
 
@@ -112,8 +112,8 @@ def chunk_data(data_chunks, chunk_size, chunk_overlap):
         chunks.append(data[i:i + chunk_size])
     return chunks
 
-def chunk_data_by_paragraph(data, chunk_size, over_lap, bound=0.75):
-    # data = "".join(data_chunks)
+def chunk_data_by_paragraph(data_chunks, chunk_size, overlap, bound=0.75):
+    data = "".join(data_chunks)
 
     # Get total length of text
     total_length = len(data)
@@ -139,7 +139,7 @@ def chunk_data_by_paragraph(data, chunk_size, over_lap, bound=0.75):
             # Update end_idx to include the paragraph delimiter
             end_idx = next_paragraph_index + 2
 
-        chunks.append(data[start_idx:end_idx + over_lap])
+        chunks.append(data[start_idx:end_idx + overlap])
 
         # Update start_idx to be the current end_idx
         start_idx = end_idx
@@ -150,6 +150,7 @@ def chunk_by_sentence(data_chunks):
     # Split by periods, question marks, exclamation marks, and ellipses
     data = "".join(data_chunks)
 
+    # The regular expression is used to find series of charaters that end with one the following chaacters (. ! ? ...)
     sentence_endings = r'(?<=[.!?…]) +'
     sentences = re.split(sentence_endings, data)
     return sentences


### PR DESCRIPTION
## what

This PR is adding the ability to performing text chunking by paragraph and sentence as per the request of issue: #12 

## why

Currently vectorflow only allows to chunk by the exact values specified by the user in the request. This PR seeks to make the chunking procedure less manual.


## Usage

This PR introduces a new value in the `EmbeddingsMetadata`. This value is an enum, it currently consists of three options:

- EXACT
- PARAGRAPH
- SENTENCE  

**EXACT** is the original method of chunking in vector flow, **PARAGRAPH** chunks based on paragraphs in the text and **SENTENCE** tries to chunk by finding the end of a sentence.

The curl request below chunks by 

```bash
curl -X POST -H 'Content-Type: multipart/form-data' -H "Authorization: INTERNAL_API_KEY" -H "X-EmbeddingAPI-Key: your-key-here" -H "X-VectorDB-Key: your-key-here" -F 'EmbeddingsMetadata={"embeddings_type": "OPEN_AI", "chunk_size": 256, "chunk_overlap": 128,  "chunk_strategy": "PARAGRAPH"}' -F 'SourceData=@./src/api/tests/fixtures/test_text.txt' -F 'VectorDBMetadata={"vector_db_type": "PINECONE", "index_name": "test", "environment": "us-east-1-aws"}'  http://localhost:8000/embed
```


## verification

Chunking by EXACT:

![chunk_by_exact](https://github.com/dgarnitz/vectorflow/assets/45427673/9cbc0aad-09ba-40dd-83d3-50821305c5c9)

Chunking by PARAGRAPH:

![chunk_by_paragraph](https://github.com/dgarnitz/vectorflow/assets/45427673/bf875d3d-36b2-4a2a-8c88-698e1d4b85e8)

Chunking by SENTENCE:

![chunk_by_sentence](https://github.com/dgarnitz/vectorflow/assets/45427673/a0567e35-3672-4271-88df-829b50d30c41)




