### PR TITLE
temporarily added a 25 MB file size limit to prevent api timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 
 VectorFlow is an open source, high throughput, fault tolerant vector embedding pipeline. With a simple API request, you can send raw data that will be embedded and stored in any vector database or returned back to you.
 
-This current version is an MVP and should not be used in production yet. Right now the system only supports uploading single TXT or PODF files at a time, up to 2GB.
+This current version is an MVP and should not be used in production yet. Right now the system only supports uploading single TXT or PODF files at a time, up to 25 MB.
 
 # Run it Locally
 

--- a/src/api/app.py
+++ b/src/api/app.py
@@ -38,9 +38,18 @@ def embed():
 
     file = request.files['SourceData']
     
+    # TODO: Remove this once the application is reworked to support large files
+    # Get the file size - Go to the end of the file, get the current position, and reset the file to the beginning
+    file.seek(0, os.SEEK_END)
+    file_size = file.tell()
+    file.seek(0)
+
+    if file_size > 25 * 1024 * 1024:
+        return jsonify({'error': 'File is too large. VectorFlow currently only supports 25 MB files or less. Larger file support coming soon.'}), 413
+    
     # empty filename means no file was selected
     if file.filename == '':
-        return jsonify({'message': 'No selected file'}), 400
+        return jsonify({'error': 'No selected file'}), 400
     
     if file and (file.filename.endswith('.txt') or file.filename.endswith('.pdf')):
         batch_count, job_id = process_file(file, vectorflow_request)


### PR DESCRIPTION
## What 
Added a file size limit to prevent timeouts on gunicorn and long waits for the user. There is now [an open issue ](https://github.com/dgarnitz/vectorflow/issues/36)to re-architecture the system to support larger file sizes that are turned into batches asynchronously. 

## Verification
Can see below that the added logic now prevents large files from being sent:

<img width="1086" alt="image" src="https://github.com/dgarnitz/vectorflow/assets/126617947/9d9f5e8f-3956-4f4f-ac99-0e368e5a5159">
