### PR TITLE
Feature deeplake

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -89,6 +89,8 @@ services:
       context: ./src
       dockerfile: worker/Dockerfile.vdb-upload-worker
     container_name: vectorflow_vdb_upload_worker
+    volumes:
+      - ./src/:/app
     env_file:
       - ./env_scripts/env_vars.env
     networks:

--- a/src/worker/requirements.txt
+++ b/src/worker/requirements.txt
@@ -10,6 +10,7 @@ certifi==2023.7.22
 cffi==1.15.1
 charset-normalizer==3.2.0
 cryptography==41.0.3
+deeplake==3.6.25 
 dnspython==2.4.1
 environs==9.5.0
 exceptiongroup==1.1.2


### PR DESCRIPTION
## What

This PR is integrating deeplake  with vectorflow. The current integration only supports adding vectors to Deep Lake Storage. Subsequent PRs will integrate other [Storage options](https://docs.activeloop.ai/storage-and-credentials/storage-options).

## Why

It seeks to close #17 

## Usage

To work with this current implementation you will need an [activeloop(deeplake)](https://app.activeloop.ai/login/?utm_source=docs&utm_medium=gitbook&utm_campaign=button) account and you will need to create API tokens.

Specify your `vector_db_type` to be **DEEPLAKE**. Place your API key in the `X-VectorDB-Key` header.
Then your `index_name` should be of this format `hub://<active_loop_user_name>/<dataset_name>`. The dataset doesn't need to exist, deeplake will create it for you but you can always use existing dataset. 

Here's a sample request:

```code
curl -X POST -H 'Content-Type: multipart/form-data' -H "Authorization: my-internal-api-key" -H "X-EmbeddingAPI-Key: your-embedding-key" -H "X-VectorDB-Key: your-deeplake-api-key" -F 'EmbeddingsMetadata={"embeddings_type": "OPEN_AI", "chunk_size": 256, "chunk_overlap": 128}' -F 'SourceData=@./src/api/tests/fixtures/test_text.txt' -F 'VectorDBMetadata={"vector_db_type": "DEEPLAKE", "index_name": "hub://eteimz/vectorflow", "environment": "us-west1-gcp-free"}'  http://localhost:8000/embed
```

## Verification

To verify this PR works I created a file named `test_vectorflow.py` and added the following content to it:

```python
import deeplake
import os

token = os.environ['ACTIVELOOP_TOKEN']

ds = deeplake.load("hub://eteimz/my_vectorflow_dataset", token=token)
```

The environment variable contains my activeloop token. Running the script above yeilds this:

![deeplake_integration_1](https://github.com/dgarnitz/vectorflow/assets/45427673/e6d18eea-6224-4aac-b288-a2962123977c)

This basically says my specified dataset doesn't exist.

Then I use vectorflow to create that dataset:

![deeplake_integration_2](https://github.com/dgarnitz/vectorflow/assets/45427673/4cc23a52-198f-4ea8-ae75-7777cb650326)

I run the script a second time:

![deeplake_integration_3](https://github.com/dgarnitz/vectorflow/assets/45427673/8156adb2-411d-439d-9fdd-c574df66174e)