### PR TITLE
added support for .docx files

### DIFF
--- a/src/api/requirements.txt
+++ b/src/api/requirements.txt
@@ -10,6 +10,7 @@ click==8.1.6
 durationpy==0.5
 Flask==2.3.2
 Flask-Cors==4.0.0
+greenlet==2.0.2
 gunicorn==21.2.0
 hjson==3.1.0
 idna==3.4
@@ -18,6 +19,7 @@ itsdangerous==2.1.2
 Jinja2==3.1.2
 jmespath==1.0.1
 kappa==0.6.0
+lxml==4.9.3
 Mako==1.2.4
 MarkupSafe==2.1.3
 packaging==23.1
@@ -26,6 +28,7 @@ placebo==0.9.0
 psycopg2-binary==2.9.6
 PyMuPDF==1.22.5
 python-dateutil==2.8.2
+python-docx==0.8.11
 python-magic==0.4.27
 python-slugify==8.0.1
 PyYAML==6.0.1


### PR DESCRIPTION
## What
added support for word .docx
does not support .doc
does not work in s3 endpoint.  

## Verification 
submitted job with word doc:
Below proves that the job was uploaded to vector db
![Screenshot (1)](https://github.com/dgarnitz/vectorflow/assets/131202513/ea0dbe99-9ba9-406b-b9e5-157befd2a88a)

Below proves that the job was completed
![Screenshot (2)](https://github.com/dgarnitz/vectorflow/assets/131202513/f5c44c4f-31bf-44b3-bf67-311b60799d85)
