### PR TITLE
fixed postgres DB connection error, cleaned up README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@
 <h4 align="center">
   <a href="https://discord.gg/MEXuahMs2F">Join our Discord</a>  |
   <a href="https://www.getvectorflow.com/">Website</a>  |  
-  <a href="mailto:dan@getvectorflow.com">Get in touch</a>
+  <a href="mailto:dan@getvectorflow.com">Get in touch</a> |
+  <a href="https://vectorflow.dev-docs.dev/docs/"> Docs</a>
 </h4>
 
 <div align="center">
@@ -22,7 +23,7 @@
 
 VectorFlow is an open source, high throughput, fault tolerant vector embedding pipeline. With a simple API request, you can send raw data that will be embedded and stored in any vector database or returned back to you. VectorFlow is multi-modal and can ingest both textual and image data. 
 
-This current version is an MVP and should not be used in production yet. Right now the system only supports uploading single files at a time, up to 25 MB. For text-based files, it supports TXT, PDF and .DOCX. For image files, it support JPG, JPEG, and PNG. 
+This current version is an MVP. We recommend using it with Kubernetes in production. Right now the system only supports uploading single files at a time, up to 25 MB. For text-based files, it supports TXT, PDF and DOCX. For image files, it support JPG, JPEG, and PNG. 
 
 # Run it Locally
 
@@ -119,7 +120,7 @@ To submit a `job` for embedding, make a `POST` request to the `/embed` endpoint 
         "hugging_face_model_name": "model-name-here"
     }'
     'VectorDBMetadata={
-        "vector_db_type": "PINECONE | QDRANT | WEAVIATE | MILVUS",
+        "vector_db_type": "PINECONE | QDRANT | WEAVIATE | MILVUS | REDIS",
         "index_name": "index_name",
         "environment": "env_name"
     }'
@@ -136,7 +137,9 @@ You will get the following payload back:
 ```
 
 ### VectorFlow API Client
-The easiest way to use VectorFlow is to with the our testing client, located in `src/testing_client.py`. Running this script will submit a document to VectorFlow for embedding. You can change the values to match your configuration. 
+The easiest way to use VectorFlow is with the our testing client, located in `src/testing_client.py`. Running this script will submit a document to VectorFlow for embedding. You can change the values to match your configuration. 
+
+Note that the `TESTING_ENV` variable is the equivalent of the `enviroment` field in the `VectorDBMetadata`, which corresponds to an environment in Pincone, a class in Weaviate, a collection in qdrant, etc. 
 
 ### Sample Curl Request
 
@@ -195,7 +198,7 @@ To perform a search, send a `POST` request to `/images/search` endpoint with an 
     'ReturnVectors': boolean,
     'TopK': integer, less than 1000,
     'VectorDBMetadata={
-        "vector_db_type": "PINECONE | QDRANT | WEAVIATE | MILVUS",
+        "vector_db_type": "PINECONE | QDRANT | WEAVIATE | MILVUS | REDIS",
         "index_name": "index_name",
         "environment": "env_name"
     }'

--- a/src/images/image_query.py
+++ b/src/images/image_query.py
@@ -61,7 +61,7 @@ def search_vector_db(embedding, image_search_request):
     if vector_db_metadata.vector_db_type == VectorDBType.PINECONE:
         return search_pinecone(embedding, image_search_request)
     else:
-        logging.error('Unsupported vector DB type:', vector_db_metadata.vector_db_type)
+        logging.error('Unsupported vector DB type: %s', vector_db_metadata.vector_db_type.value)
         return {"error": "Unsupported vector DB type"}
     
 def search_pinecone(embedding, image_search_request):

--- a/src/scripts/create_local_qdrant.py
+++ b/src/scripts/create_local_qdrant.py
@@ -37,3 +37,14 @@ print("collection created")
 print("verifying collection")
 collection = client.get_collection(collection_name="test-512")
 print(collection)
+
+print("creating image embedding testing collection with 1024 dimensions")
+client.recreate_collection(
+    collection_name="test-1024",
+    vectors_config=models.VectorParams(size=1024, distance=models.Distance.COSINE),
+)
+print("collection created")
+
+print("verifying collection")
+collection = client.get_collection(collection_name="test-1024")
+print(collection)


### PR DESCRIPTION
## What
- Added logic to test postgres connection before DB calls and to recycle connections
- Added logic to retry writing to the DB if the connection fails
- Refactored all DB calls to use the retry method
- Added an additional default collection to local qdrant

If this does not resolve the error going forward, can also do the following:
```
Database Configuration:

On the PostgreSQL side, you can also adjust the tcp_keepalives_idle, tcp_keepalives_interval, and tcp_keepalives_count settings to control when the server should start sending TCP keepalive messages and how often. Adjusting these settings can help in preventing premature connection terminations due to inactivity. However, do consult the PostgreSQL documentation and be aware of the implications before changing these settings.

Connection Pooling Solutions:

You can use connection pooling solutions like PgBouncer which maintains connections even if your application does not. PgBouncer can be placed between your application and PostgreSQL to pool connections. This way, if the application's connection goes idle, PgBouncer keeps the actual connection to the PostgreSQL server alive.
```

## Verification 
Can see various jobs completing successfully with Hugging Face open source embeddings and local qdrant:

<img width="638" alt="image" src="https://github.com/dgarnitz/vectorflow/assets/126617947/bbe03379-bbe2-42d2-a95e-46e04a38c18c">
