### PR TITLE
Add embedding webhook and doc ids

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@
   <a href="https://discord.gg/MEXuahMs2F">Join our Discord</a>  |
   <a href="https://www.getvectorflow.com/">Website</a>  |  
   <a href="mailto:dan@getvectorflow.com">Get in touch</a> |
-  <a href="https://vectorflow.dev-docs.dev/docs/"> Docs</a>
+  <a href="https://vectorflow.dev-docs.dev/docs/">Docs</a> |
+  <a href="https://app.getvectorflow.com/">Free Hosted Version</a> 
 </h4>
 
 <div align="center">
@@ -117,13 +118,14 @@ To submit a `job` for embedding, make a `POST` request to the `/embed` endpoint 
         "chunk_size": 512,
         "chunk_overlap": 128,
         "chunk_strategy": "EXACT | PARAGRAPH | SENTENCE",
-        "hugging_face_model_name": "model-name-here"
+        "hugging_face_model_name": "sentence-transformer-model-name-here"
     }'
     'VectorDBMetadata={
         "vector_db_type": "PINECONE | QDRANT | WEAVIATE | MILVUS | REDIS",
         "index_name": "index_name",
         "environment": "env_name"
     }'
+    'DocumentID=your-optional-internal-tracking-id'
 }
 ```
 
@@ -135,6 +137,9 @@ You will get the following payload back:
     'JobID': job_id
 }
 ```
+
+### Raw Embeddings Webhook
+If you wish to use VectorFlow only for chunking and generating embeddings, pass a `WebhookURL` parameter in the body of the `/embed` request and a `X-Webhook-Key` as a header. VectorFlow assumes a webhook key is required for writing back to any endpoint. 
 
 ### VectorFlow API Client
 The easiest way to use VectorFlow is with the our testing client, located in `src/testing_client.py`. Running this script will submit a document to VectorFlow for embedding. You can change the values to match your configuration. 
@@ -229,7 +234,7 @@ We love feedback from the community. If you have an idea of how to make this pro
 
 Our roadmap is outlined in the section below and we would love help in building it out. Our open issues are a great place to start and can be viewed [here](https://github.com/dgarnitz/vectorflow/issues). If you want to work on something not listed there, we recommend you open an issue with a proposed approach in mind before submitting a PR.
 
-Please tag `dgarnitz` on all PRs.
+Please tag `dgarnitz` on all PRs and update the README to reflect your changes.
 
 ### Testing
 
@@ -254,11 +259,12 @@ We also recommend you add verification evidence, such as screenshots, that show 
 
 # Roadmap
 
-- [ ] Connectors to other vector databases
-- [ ] Support for more files types such as `csv`, `word`, `xls`, etc
 - [ ] Support for multi-file, directory data ingestion from sources such as Salesforce, Google Drive, etc
 - [ ] Retry mechanism
 - [ ] Langchain & Llama Index integrations
 - [ ] Support callbacks for writing object metadata to a separate store
 - [ ] Dynamically configurable vector DB schemas
 - [ ] Deduplication capabilities
+- [ ] Vector version control
+- [ ] "Smart" chunker
+- [ ] "Smart" metadata extractor

--- a/src/api/tests/test_app.py
+++ b/src/api/tests/test_app.py
@@ -145,7 +145,16 @@ class TestApp(unittest.TestCase):
 
         # assert
         self.assertEqual(len(chunks), 3)
-        
+
+    def test_get_s3_file_name(self):
+        # arrange
+        pre_signed_url = "https://s3.amazonaws.com/my-bucket-name/myfolder/myfile.txt"
+
+        # act
+        filename = app.get_s3_file_name(pre_signed_url)
+
+        # assert
+        self.assertEqual(filename, "myfile.txt")
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/api/vectorflow_request.py
+++ b/src/api/vectorflow_request.py
@@ -11,3 +11,5 @@ class VectorflowRequest:
         self.vector_db_metadata = VectorDBMetadata._from_request(request)
         self.embeddings_metadata = EmbeddingsMetadata._from_request(request)
         self.lines_per_batch = int(request.form.get('LinesPerBatch')) if request.form.get('LinesPerBatch') else 1000
+        self.webhook_key = request.headers.get('X-Webhook-Key')
+        self.document_id = request.form.get('DocumentID')

--- a/src/models/job.py
+++ b/src/models/job.py
@@ -19,3 +19,6 @@ class Job(Base):
 
     vector_db_metadata_id = Column(Integer, ForeignKey('vector_db_metadata.id'))
     vector_db_metadata = relationship(VectorDBMetadata)
+
+    webhook_key = Column(String)
+    document_id = Column(String)

--- a/src/services/database/batch_service.py
+++ b/src/services/database/batch_service.py
@@ -9,6 +9,11 @@ from shared.batch_status import BatchStatus
 def create_batches(db: Session, batches: list[Batch]):
     db.add_all(batches)
     db.commit()
+    
+    # TODO: update to a bulk select or different strategy at scale since this approach
+    # has poor performance
+    for batch in batches:
+        db.refresh(batch)
     return batches
 
 def get_batch(db: Session, batch_id: str):

--- a/src/services/database/job_service.py
+++ b/src/services/database/job_service.py
@@ -4,8 +4,15 @@ from models.job import Job
 from shared.batch_status import BatchStatus
 from shared.job_status import JobStatus
 
-def create_job(db: Session, webhook_url: str, source_filename: str):
-    job = Job(webhook_url=webhook_url, source_filename=source_filename)
+def create_job(db: Session, request, source_filename: str):
+    job = Job(source_filename = source_filename)
+    if request.webhook_url:
+        job.webhook_url = request.webhook_url
+    if request.webhook_key:
+        job.webhook_key = request.webhook_key
+    if request.document_id:
+        job.document_id = request.document_id
+
     db.add(job)
     db.commit()
     db.refresh(job)

--- a/src/shared/utils.py
+++ b/src/shared/utils.py
@@ -1,4 +1,5 @@
 import uuid
+import requests
 
 def generate_uuid_from_tuple(t, namespace_uuid='6ba7b810-9dad-11d1-80b4-00c04fd430c8'):
     namespace = uuid.UUID(namespace_uuid)
@@ -9,3 +10,24 @@ def generate_uuid_from_tuple(t, namespace_uuid='6ba7b810-9dad-11d1-80b4-00c04fd4
 
 def str_to_bool(value):
     return str(value).lower() in ["true", "1", "yes"]
+
+def send_embeddings_to_webhook(text_embeddings_list, job):
+    headers = {
+        "X-Embeddings-Webhook-Key": job.webhook_key,
+        "Content-Type": "application/json"
+    }
+
+    # text_embeddings_list is list[(str, list[float])], should serialize automatically without json.dumps()
+    data = {
+        'Embeddings': text_embeddings_list,
+        'DocumentID': job.document_id,
+        'JobID': job.id
+    }
+
+    response = requests.post(
+        job.webhook_url, 
+        headers=headers, 
+        json=data
+    )
+
+    return response

--- a/src/shared/utils.py
+++ b/src/shared/utils.py
@@ -20,7 +20,7 @@ def send_embeddings_to_webhook(text_embeddings_list, job):
     # text_embeddings_list is list[(str, list[float])], should serialize automatically without json.dumps()
     data = {
         'Embeddings': text_embeddings_list,
-        'DocumentID': job.document_id,
+        'DocumentID': job.document_id if job.document_id else "",
         'JobID': job.id
     }
 

--- a/src/testing_client.py
+++ b/src/testing_client.py
@@ -8,10 +8,10 @@ import json
 filepath = './api/tests/fixtures/test_medium_text.txt'
 url = "http://localhost:8000/embed"
 embedding_key = os.getenv("OPEN_AI_KEY")
-vector_db_key = os.getenv("MILVUS_KEY")
-embedding_type="OPEN_AI"
-vector_db_type = "MILVUS"
-index_name = "test1536"
+vector_db_key = os.getenv("QDRANT_KEY")
+embedding_type="HUGGING_FACE"
+vector_db_type = "QDRANT"
+index_name = "test-1536"
 testing_environment = os.getenv("TESTING_ENV")
 
 ##################
@@ -22,19 +22,23 @@ headers = {
     "Authorization": os.getenv("INTERNAL_API_KEY"),
     "X-EmbeddingAPI-Key": embedding_key,
     "X-VectorDB-Key": vector_db_key,
+    "X-Webhook-Key": "test-webhook-key",
 }
 
 data = {
     'EmbeddingsMetadata': json.dumps({
         "embeddings_type": embedding_type, 
         "chunk_size": 256, 
-        "chunk_overlap": 128
+        "chunk_overlap": 128,
+        "hugging_face_model_name": "BAAI/bge-small-en"
     }),
     'VectorDBMetadata': json.dumps({
         "vector_db_type": vector_db_type, 
         "index_name": index_name,
         "environment": testing_environment
-    })
+    }),
+    'DocumentID': "test-document-id",
+    'WebhookURL': 'http://host.docker.internal:6060/vectors'
 }
 
 files = {

--- a/src/worker/tests/test_vdb_upload_worker.py
+++ b/src/worker/tests/test_vdb_upload_worker.py
@@ -13,7 +13,7 @@ class TestVDBUploadWorker(unittest.TestCase):
     @patch('sqlalchemy.orm.session.Session.refresh')
     @patch('services.database.batch_service.update_batch_status_with_successful_minibatch')
     @patch('services.database.job_service.update_job_status')
-    @patch('services.database.database.get_db')
+    @patch('services.database.database.safe_db_operation')
     @patch('services.database.job_service.get_job')
     @patch('services.database.batch_service.get_batch')
     @patch('worker.vdb_upload_worker.write_embeddings_to_vector_db')
@@ -24,7 +24,7 @@ class TestVDBUploadWorker(unittest.TestCase):
         mock_write_embeddings_to_vector_db, 
         mock_get_batch, 
         mock_get_job, 
-        mock_get_db,
+        mock_safe_db_operation,
         mock_update_job_status,
         mock_update_batch_status_with_successful_minibatch,
         mock_db_refresh,
@@ -40,7 +40,7 @@ class TestVDBUploadWorker(unittest.TestCase):
         mock_update_batch_status_with_successful_minibatch.return_value = BatchStatus.COMPLETED
         mock_get_batch.return_value = batch
         mock_get_job.return_value = job
-        mock_get_db.return_value = "test_db"
+        mock_safe_db_operation.return_value = "test_db"
 
         # act
         vdb_upload_worker.upload_batch(batch, text_embedding_list)
@@ -53,7 +53,7 @@ class TestVDBUploadWorker(unittest.TestCase):
     @patch('sqlalchemy.orm.session.Session.refresh')
     @patch('services.database.batch_service.update_batch_status')
     @patch('services.database.job_service.update_job_status')
-    @patch('services.database.database.get_db')
+    @patch('services.database.database.safe_db_operation')
     @patch('services.database.job_service.get_job')
     @patch('services.database.batch_service.get_batch')
     @patch('worker.vdb_upload_worker.write_embeddings_to_vector_db')
@@ -64,7 +64,7 @@ class TestVDBUploadWorker(unittest.TestCase):
         mock_write_embeddings_to_vector_db, 
         mock_get_batch, 
         mock_get_job, 
-        mock_get_db,
+        mock_safe_db_operation,
         mock_update_job_status,
         mock_update_batch_status,
         mock_db_refresh,
@@ -79,7 +79,7 @@ class TestVDBUploadWorker(unittest.TestCase):
         mock_write_embeddings_to_vector_db.return_value = 0
         mock_get_batch.return_value = batch
         mock_get_job.return_value = job
-        mock_get_db.return_value = "test_db"
+        mock_safe_db_operation.return_value = "test_db"
 
         # act
         vdb_upload_worker.upload_batch(batch, text_embedding_list)

--- a/src/worker/tests/test_worker.py
+++ b/src/worker/tests/test_worker.py
@@ -14,7 +14,7 @@ class TestWorker(unittest.TestCase):
     @patch('sqlalchemy.orm.session.Session.refresh')
     @patch('services.database.batch_service.update_batch_status')
     @patch('services.database.job_service.update_job_status')
-    @patch('services.database.database.get_db')
+    @patch('services.database.database.safe_db_operation')
     @patch('services.database.job_service.get_job')
     @patch('services.database.batch_service.get_batch')
     @patch('worker.worker.embed_openai_batch')
@@ -25,7 +25,7 @@ class TestWorker(unittest.TestCase):
         mock_embed_openai_batch, 
         mock_get_batch, 
         mock_get_job, 
-        mock_get_db,
+        mock_safe_db_operation,
         mock_update_job_status,
         mock_update_batch_status,
         mock_db_refresh,
@@ -38,7 +38,7 @@ class TestWorker(unittest.TestCase):
         mock_embed_openai_batch.return_value = text_embeddings_list
         mock_get_batch.return_value = batch
         mock_get_job.return_value = job
-        mock_get_db.return_value = "test_db"
+        mock_safe_db_operation.return_value = "test_db"
 
         # act
         worker.process_batch(batch.id, source_data)
@@ -51,7 +51,7 @@ class TestWorker(unittest.TestCase):
     @patch('sqlalchemy.orm.session.Session.refresh')
     @patch('services.database.batch_service.update_batch_status')
     @patch('services.database.job_service.update_job_status')
-    @patch('services.database.database.get_db')
+    @patch('services.database.database.safe_db_operation')
     @patch('services.database.job_service.get_job')
     @patch('services.database.batch_service.get_batch')
     @patch('worker.worker.embed_hugging_face_batch')
@@ -62,7 +62,7 @@ class TestWorker(unittest.TestCase):
         mock_embed_hugging_face_batch, 
         mock_get_batch, 
         mock_get_job, 
-        mock_get_db,
+        mock_safe_db_operation,
         mock_update_job_status,
         mock_update_batch_status,
         mock_db_refresh,
@@ -77,7 +77,7 @@ class TestWorker(unittest.TestCase):
         mock_embed_hugging_face_batch.return_value = text_embeddings_list
         mock_get_batch.return_value = batch
         mock_get_job.return_value = job
-        mock_get_db.return_value = "test_db"
+        mock_safe_db_operation.return_value = "test_db"
 
         # act
         worker.process_batch(batch.id, source_data)
@@ -89,7 +89,7 @@ class TestWorker(unittest.TestCase):
     @patch('sqlalchemy.orm.session.Session.refresh')
     @patch('services.database.batch_service.update_batch_status')
     @patch('services.database.job_service.update_job_status')
-    @patch('services.database.database.get_db')
+    @patch('services.database.database.safe_db_operation')
     @patch('services.database.job_service.get_job')
     @patch('services.database.batch_service.get_batch')
     @patch('worker.worker.embed_openai_batch')
@@ -100,7 +100,7 @@ class TestWorker(unittest.TestCase):
         mock_embed_openai_batch, 
         mock_get_batch, 
         mock_get_job, 
-        mock_get_db,
+        mock_safe_db_operation,
         mock_update_job_status,
         mock_update_batch_status,
         mock_db_refresh,
@@ -112,7 +112,7 @@ class TestWorker(unittest.TestCase):
         mock_embed_openai_batch.return_value = None
         mock_get_batch.return_value = batch
         mock_get_job.return_value = job
-        mock_get_db.return_value = "test_db"
+        mock_safe_db_operation.return_value = "test_db"
 
         # act
         worker.process_batch(batch.id, source_data)
@@ -125,7 +125,7 @@ class TestWorker(unittest.TestCase):
     @patch('sqlalchemy.orm.session.Session.refresh')
     @patch('services.database.batch_service.update_batch_status')
     @patch('services.database.job_service.update_job_status')
-    @patch('services.database.database.get_db')
+    @patch('services.database.database.safe_db_operation')
     @patch('services.database.job_service.get_job')
     @patch('services.database.batch_service.get_batch')
     @patch('worker.worker.embed_openai_batch')
@@ -136,7 +136,7 @@ class TestWorker(unittest.TestCase):
         mock_embed_openai_batch, 
         mock_get_batch, 
         mock_get_job, 
-        mock_get_db,
+        mock_safe_db_operation,
         mock_update_job_status,
         mock_update_batch_status,
         mock_db_refresh,
@@ -148,7 +148,7 @@ class TestWorker(unittest.TestCase):
         mock_embed_openai_batch.return_value = 0
         mock_get_batch.return_value = batch
         mock_get_job.return_value = job
-        mock_get_db.return_value = "test_db"
+        mock_safe_db_operation.return_value = "test_db"
 
         # act
         worker.process_batch(batch.id, source_data)


### PR DESCRIPTION
## What 
- Added support for returning the vectors to a webhook url with a webhook key. This will send the vectors as a JSON payload
- Added support for uploading Document IDs and returning them as part of the embedding payload

This is in response to items 1 and 4 [in this issue here](https://github.com/dgarnitz/vectorflow/issues/60)

## Verification
Can see that this succeeds with the python testing client in its current state, using open source embeddings models

<img width="676" alt="image" src="https://github.com/dgarnitz/vectorflow/assets/126617947/7bc931ec-3ccb-4f78-adf5-cc9e22d831a9">

Also this is a print out from a test API endpoint to verify that the embeddings were sent
<img width="593" alt="image" src="https://github.com/dgarnitz/vectorflow/assets/126617947/6da4c89b-0542-4589-ac73-7896106f2bd0">


### Testing script
Below is a sample Flask endpoint that can be used to test this:
```
@app.route('/vectors', methods=['POST'])
def receive_vectors():
    data_str = request.data.decode('utf-8')

    try:
        data = json.loads(data_str)
    except json.JSONDecodeError:
        print("json error")
        return jsonify({"error": "Failed to decode the received data"}), 400

    embeddings = data.get('Embeddings', [])
    document_id = data.get('DocumentID')
    job_id = data.get('JobID')

    try:
        embeddings = [(item[0], item[1]) for item in embeddings]
    except (TypeError, IndexError):
        print("Error here")
        return jsonify({"error": "Failed to parse embeddings"}), 400

    print({
        "Embeddings": len(embeddings),
        "DocumentID": document_id,
        "JobID": job_id
    })

    return jsonify({"message": "Data received and printed!"}), 200
```