### PR TITLE
Add html and custom chunker

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 
 VectorFlow is an open source, high throughput, fault tolerant vector embedding pipeline. With a simple API request, you can send raw data that will be chunked, embedded and stored in any vector database or returned back to you. VectorFlow is multi-modal and can ingest both textual and image data. 
 
-This current version is an MVP. We recommend using it with Kubernetes in production. Right now the system only supports uploading single files at a time, up to 25 MB. For text-based files, it supports TXT, PDF and DOCX. For image files, it support JPG, JPEG, and PNG. 
+This current version is an MVP. We recommend using it with Kubernetes in production. Right now the system only supports uploading single files at a time, up to 25 MB. For text-based files, it supports TXT, PDF, HTML and DOCX. For image files, it support JPG, JPEG, and PNG. 
 
 # Run it Locally
 With two simple commands you can set up VectorFlow locally:
@@ -47,15 +47,7 @@ The best way to run VectorFlow is via `docker compose`. If you are running this 
 
 ### 1) Set Environment Variables
 
-First create a folder in the root for all the environment variables:
-
-```
-mkdir env_scripts
-cd env_scripts
-touch env_vars.env
-```
-
-This creates a file called `env_vars.env` in the `env_scripts` folder to add all the environment variables mentioned below. You only need to set the `LOCAL_VECTOR_DB` variable if you are running qdrant, Milvus or Weaviate locally.  
+First create a folder, `env_scripts`, in the root for all the environment variables, then create `env_vars.env` in the `env_scripts` folder to add all the environment variables mentioned below. You only need to set the `LOCAL_VECTOR_DB` variable if you are running qdrant, Milvus or Weaviate locally.  
 
 ```
 INTERNAL_API_KEY=your-choice
@@ -134,7 +126,7 @@ To submit a `job` for embedding, make a `POST` request to the `/embed` endpoint 
         "hugging_face_model_name": "sentence-transformer-model-name-here"
     }'
     'VectorDBMetadata={
-        "vector_db_type": "PINECONE | QDRANT | WEAVIATE | MILVUS | REDIS",
+        "vector_db_type": "PINECONE | QDRANT | WEAVIATE | MILVUS | REDIS | LANCEDB",
         "index_name": "index_name",
         "environment": "env_name"
     }'

--- a/src/api/app.py
+++ b/src/api/app.py
@@ -133,7 +133,7 @@ def s3_presigned_url():
             return jsonify({'message': f"Successfully added {batch_count} batches to the queue", 'JobID': job.id}), 200
         
         else:
-            return jsonify({'error': 'Uploaded file is not a TXT, PDF or DOCX file'}), 400
+            return jsonify({'error': 'Uploaded file is not a TXT, PDF, HTML or DOCX file'}), 400
     else:
         print('Failed to download file:', response.status_code, response.reason)
 
@@ -156,6 +156,10 @@ def process_file(file, vectorflow_request):
         file_content = "\n".join([document.text for document in documents])
         temp_file_path.unlink()
     
+    elif file.filename.endswith('.html'):
+        content = file.read().decode('utf-8')
+        file_content = repr(content)
+
     else:
         pdf_data = BytesIO(file.read())
         with fitz.open(stream=pdf_data, filetype='pdf') as doc:
@@ -337,7 +341,7 @@ def get_s3_file_name(pre_signed_url):
     return file_name
 
 def is_valid_file_type(file):
-    supported_types = ['.txt', '.docx', '.pdf', '.md']
+    supported_types = ['.txt', '.docx', '.pdf', '.md', '.html']
     for type in supported_types:
         if file.filename.endswith(type):
             return True

--- a/src/shared/chunk_strategy.py
+++ b/src/shared/chunk_strategy.py
@@ -4,3 +4,4 @@ class ChunkStrategy(Enum):
     EXACT = 'exact'
     PARAGRAPH = 'paragraph'
     SENTENCE = 'sentence'
+    CUSTOM = 'custom'

--- a/src/worker/worker.py
+++ b/src/worker/worker.py
@@ -153,7 +153,7 @@ def chunk_data(batch, source_data, job):
     elif batch.embeddings_metadata.chunk_strategy == ChunkStrategy.CUSTOM:
         try:
             from custom_chunker import chunker
-            chunker(source_data)
+            chunked_data = chunker(source_data)
         except ImportError:
             logging.error("Failed to import chunker from custom_chunker.py")
     

--- a/src/worker/worker.py
+++ b/src/worker/worker.py
@@ -149,6 +149,14 @@ def chunk_data(batch, source_data, job):
 
     elif batch.embeddings_metadata.chunk_strategy == ChunkStrategy.SENTENCE:
         chunked_data = chunk_by_sentence(source_data, batch.embeddings_metadata.chunk_size, batch.embeddings_metadata.chunk_overlap)
+    
+    elif batch.embeddings_metadata.chunk_strategy == ChunkStrategy.CUSTOM:
+        try:
+            from custom_chunker import chunker
+            chunker(source_data)
+        except ImportError:
+            logging.error("Failed to import chunker from custom_chunker.py")
+    
     else:
         chunked_data = chunk_data_exact(source_data, batch.embeddings_metadata.chunk_size, batch.embeddings_metadata.chunk_overlap)
 


### PR DESCRIPTION
## What
- Adding HTML ingestion to `embed` endpoint
- Adding support for a custom chunker. This must be called with a defined interface, `chunker(source_data)` where `source_data` is a list of strings, typically representing each line of input in a file. The `chunker` method must be in a file called `custom_chunker.py`

## Why 
Requested by ArguFlow

## Verification
Can see that the request to embed and upload an HTML file succeeds:
<img width="836" alt="image" src="https://github.com/dgarnitz/vectorflow/assets/126617947/6f9a1a43-1915-46d0-8298-d6886b94f753">

Can see in the pod logs here that the HTML converts to a string succesfully:
<img width="960" alt="image" src="https://github.com/dgarnitz/vectorflow/assets/126617947/653f69ea-52ff-4764-ae7d-f39a90202e58">


And can see the custom chunker being called:
<img width="485" alt="image" src="https://github.com/dgarnitz/vectorflow/assets/126617947/39888933-4af3-449e-92f0-af249dc9b957">


Unit tests all still pass
