### PR TITLE
Represent chunks as dict

### DIFF
--- a/clients/hugging_face_upload_client.py
+++ b/clients/hugging_face_upload_client.py
@@ -8,11 +8,10 @@ import json
 filepath = './api/tests/fixtures/test_medium_text.txt'
 url = "http://localhost:8000/embed"
 embedding_key = os.getenv("OPEN_AI_KEY")
-vector_db_key = os.getenv("QDRANT_KEY")
 embedding_type="HUGGING_FACE"
 vector_db_type = "QDRANT"
-index_name = "test-1536" # NOTE: this is not actually needed with the webhook
-testing_environment = os.getenv("TESTING_ENV")
+index_name = "test-384"
+testing_environment = "qdrant"
 internal_api_key = "test123"
 
 ##################
@@ -21,9 +20,7 @@ internal_api_key = "test123"
 
 headers = {
     "Authorization": internal_api_key,
-    "X-EmbeddingAPI-Key": embedding_key,
-    "X-VectorDB-Key": vector_db_key,
-    "X-Webhook-Key": "test-webhook-key",
+    "X-EmbeddingAPI-Key": embedding_key
 }
 
 data = {
@@ -37,10 +34,7 @@ data = {
         "vector_db_type": vector_db_type, 
         "index_name": index_name,
         "environment": testing_environment
-    }),
-    'DocumentID': "test-document-id",
-    'WebhookURL': 'http://host.docker.internal:6060/vectors',
-    'ChunkValidationURL': 'http://host.docker.internal:6060/validate',
+    })
 }
 
 files = {

--- a/clients/webhook_test_api.py
+++ b/clients/webhook_test_api.py
@@ -21,12 +21,12 @@ def receive_vectors():
     document_id = data.get('DocumentID')
     job_id = data.get('JobID')
 
-    # Assuming embeddings is a list of structures
+    # Assuming embeddings is a list of dictionaries
     # Convert the structure back to a tuple: (str, list[float])
     try:
-        embeddings = [(item[0], item[1]) for item in embeddings]
+        embeddings = [(item['text'], item['vector']) for item in embeddings]
     except (TypeError, IndexError):
-        print("Error here")
+        print(" #### ERROR HERE ####")
         return jsonify({"error": "Failed to parse embeddings"}), 400
 
     # Print the data

--- a/src/api/tests/fixtures/test_medium_text.txt
+++ b/src/api/tests/fixtures/test_medium_text.txt
@@ -123,6 +123,8 @@ let's write more stuff to check how the chunking actually performs.
 let's write more stuff to check how the chunking actually performs. 
 let's write more stuff to check how the chunking actually performs. 
 let's write more stuff to check how the chunking actually performs. let's write more stuff to check how the chunking actually performs. 
+
+
 let's write more stuff to check how the chunking actually performs. 
 let's write more stuff to check how the chunking actually performs. 
 let's write more stuff to check how the chunking actually performs. 
@@ -141,3 +143,5 @@ let's write more stuff to check how the chunking actually performs.
 let's write more stuff to check how the chunking actually performs. 
 let's write more stuff to check how the chunking actually performs. 
 let's write more stuff to check how the chunking actually performs. 
+
+is this a question? how will it do handling this? lets see!

--- a/src/shared/utils.py
+++ b/src/shared/utils.py
@@ -1,5 +1,6 @@
 import uuid
 import requests
+import json
 
 def generate_uuid_from_tuple(t, namespace_uuid='6ba7b810-9dad-11d1-80b4-00c04fd430c8'):
     namespace = uuid.UUID(namespace_uuid)
@@ -11,15 +12,14 @@ def generate_uuid_from_tuple(t, namespace_uuid='6ba7b810-9dad-11d1-80b4-00c04fd4
 def str_to_bool(value):
     return str(value).lower() in ["true", "1", "yes"]
 
-def send_embeddings_to_webhook(text_embeddings_list, job):
+def send_embeddings_to_webhook(embedded_chunks: list[dict], job):
     headers = {
         "X-Embeddings-Webhook-Key": job.webhook_key,
         "Content-Type": "application/json"
     }
-
-    # text_embeddings_list is list[(str, list[float])], should serialize automatically without json.dumps()
+    
     data = {
-        'Embeddings': text_embeddings_list,
+        'Embeddings': embedded_chunks,
         'DocumentID': job.document_id if (hasattr(job, 'document_id') and job.document_id) else "",
         'JobID': job.id
     }

--- a/src/worker/tests/test_vdb_upload_worker.py
+++ b/src/worker/tests/test_vdb_upload_worker.py
@@ -90,7 +90,7 @@ class TestVDBUploadWorker(unittest.TestCase):
     
     def test_create_pinecone_source_chunk_dict(self):
             # arrange
-            data = "thisistest" * 38 + "test"
+            data = "thisistest" * 116 + "test"
             chunks = worker.chunk_data_exact(data, 256, 128)
             text_embeddings_dict = [(chunk, [1.0, 2.0, 3.0, 4.0, 5.0]) for chunk in chunks]
             batch_id = 1

--- a/src/worker/tests/test_worker.py
+++ b/src/worker/tests/test_worker.py
@@ -228,8 +228,8 @@ class TestWorker(unittest.TestCase):
 
         # assert
         self.assertEqual(len(chunks), 3)
-        self.assertEqual(len(chunks[0]), 1024)
-        self.assertEqual(len(chunks[2]), 512)
+        self.assertEqual(len(chunks[0]['text']), 1024)
+        self.assertEqual(len(chunks[2]['text']), 512)
 
     def test_chunk_paragraph(self):
         # We input our last paragraph manually because ending the text with a new paragraph character will create a 5th paragraph, which is empty 
@@ -247,7 +247,7 @@ class TestWorker(unittest.TestCase):
         chunks = worker.chunk_data_by_paragraph(data, chunk_size=10, overlap=2)
         # these are the ninth and tenth tokens in the example
         expected_overlap = ' second example'
-        self.assertEqual(chunks[1][:15], expected_overlap)
+        self.assertEqual(chunks[1]['text'][:15], expected_overlap)
 
     def test_chunk_paragraph_bound(self):
         data = ["This is \n\n a very early paragraph."]
@@ -277,9 +277,7 @@ class TestWorker(unittest.TestCase):
 
         #these are the ninth and tenth tokens in the example
         expected_overlap = ' longer so'
-        self.assertEqual(chunks[1][0:10], expected_overlap)
-
-
+        self.assertEqual(chunks[1]['text'][0:10], expected_overlap)
 
     def test_create_openai_batches(self):
         # arrange

--- a/src/worker/tests/test_worker.py
+++ b/src/worker/tests/test_worker.py
@@ -286,7 +286,7 @@ class TestWorker(unittest.TestCase):
         batches = ["test"] * config.MAX_OPENAI_EMBEDDING_BATCH_SIZE * 4
 
         # act
-        openai_batches = worker.create_upload_batches(batches, config.MAX_OPENAI_EMBEDDING_BATCH_SIZE)
+        openai_batches = worker.create_batches_for_embedding(batches, config.MAX_OPENAI_EMBEDDING_BATCH_SIZE)
 
         # assert
         self.assertEqual(len(openai_batches), 4)


### PR DESCRIPTION
## What 
Altered our chunking in two ways:
1) chunks are now represented as `dict` with `text` key for the raw text and `vector` for the embedding
2) the custom chunker can now support returning chunks of any form as long as they have those two keys and all values are JSON serializable

## Why
VectorFlow's off the shelf chunkers may not be sufficient for certain use cases. This will allow users to handle sensitive data with custom chunkers as well as return chunks with metadata that can be uploaded to the vector DB for hybrid searching (this will be implemented in a subsequent PR).

## Verification:
The following cases were tested successfully to verify this feature works:
<img width="612" alt="image" src="https://github.com/dgarnitz/vectorflow/assets/126617947/6c26e312-57b2-43ee-aa2e-3b2297ba5cff">

All unit tests pass:

Worker:
<img width="774" alt="image" src="https://github.com/dgarnitz/vectorflow/assets/126617947/98ed1840-e921-47df-8ea0-ef819c98c5d1">

VDB Worker:
<img width="862" alt="image" src="https://github.com/dgarnitz/vectorflow/assets/126617947/0dbf5e4c-92ae-4d3f-b787-83b357ab22ef">

API:
<img width="742" alt="image" src="https://github.com/dgarnitz/vectorflow/assets/126617947/611ca1e7-9f05-4d28-b84a-a609d6d6aca0">




 