### PR TITLE
Re add character chunking

### DIFF
--- a/src/shared/chunk_strategy.py
+++ b/src/shared/chunk_strategy.py
@@ -2,6 +2,9 @@ from enum import Enum
 
 class ChunkStrategy(Enum):
     EXACT = 'exact'
+    EXACT_BY_CHARACTERS = 'exact_by_characters'
     PARAGRAPH = 'paragraph'
+    PARAGRAPH_BY_CHARACTERS = 'paragraph_by_characters'
     SENTENCE = 'sentence'
+    SENTENCE_BY_CHARACTERS = 'sentence_by_characters'
     CUSTOM = 'custom'

--- a/src/worker/tests/test_worker.py
+++ b/src/worker/tests/test_worker.py
@@ -239,6 +239,7 @@ class TestWorker(unittest.TestCase):
         chunks = worker.chunk_data_by_paragraph(data, chunk_size=16, overlap=0)
 
         self.assertEqual(len(chunks), 4)
+        self.assertEqual(type(chunks[0]), dict)
 
     def test_chunk_paragraph_overlap(self):
         data = ["This is an example paragraph. With a second example sentence.\n\n"]
@@ -248,6 +249,7 @@ class TestWorker(unittest.TestCase):
         # these are the ninth and tenth tokens in the example
         expected_overlap = ' second example'
         self.assertEqual(chunks[1]['text'][:15], expected_overlap)
+        self.assertEqual(type(chunks[0]), dict)
 
     def test_chunk_paragraph_bound(self):
         data = ["This is \n\n a very early paragraph."]
@@ -255,6 +257,7 @@ class TestWorker(unittest.TestCase):
         chunks = worker.chunk_data_by_paragraph(data, chunk_size=10, overlap=0, bound=0.5)
 
         self.assertEqual(len(chunks), 1)
+        self.assertEqual(type(chunks[0]), dict)
 
     def test_chunk_sentence(self):
         data = ["I am a sentence. I am a sentence but with a question? I am still a sentence! Can I consider myself a sentence..."]
@@ -262,6 +265,7 @@ class TestWorker(unittest.TestCase):
         chunks = worker.chunk_by_sentence(data, chunk_size=50, overlap=0)
 
         self.assertEqual(len(chunks), 4)
+        self.assertEqual(type(chunks[0]), dict)
 
     def test_chunk_sentence_too_big(self):
         data = ["I am a sentence. I am a sentence but with a question? I am still a sentence! Can I consider myself a sentence... Blahblah Blahblah Blahblah Blahblah Blahblah Blahblah ."]
@@ -269,6 +273,7 @@ class TestWorker(unittest.TestCase):
         chunks = worker.chunk_by_sentence(data, chunk_size=10, overlap=0)
 
         self.assertEqual(len(chunks), 6)
+        self.assertEqual(type(chunks[0]), dict)
     
     def test_chunk_sentence_overlap(self):
         data = ["This is a sentence that needs to be longer so that we have enough words for the test"]
@@ -278,6 +283,7 @@ class TestWorker(unittest.TestCase):
         #these are the ninth and tenth tokens in the example
         expected_overlap = ' longer so'
         self.assertEqual(chunks[1]['text'][0:10], expected_overlap)
+        self.assertEqual(type(chunks[0]), dict)
 
     def test_create_openai_batches(self):
         # arrange
@@ -288,6 +294,53 @@ class TestWorker(unittest.TestCase):
 
         # assert
         self.assertEqual(len(openai_batches), 4)
+
+    def test_chunk_data_exact_by_characters(self):
+        # arrange
+        # 384 characters, should be 3 chunks, since the last chunk will be partial
+        data = ["thisistest"] * 38
+        data.append("test") 
+
+        # act
+        chunks = worker.chunk_data_exact_by_characters(data, 256, 128)
+
+        # assert
+        self.assertEqual(len(chunks), 3)
+        self.assertEqual(len(chunks[2]['text']), 128)
+        self.assertEqual(type(chunks[0]), dict)
+
+    def test_chunk_paragraph_by_characters(self):
+        data = ["This is an example paragraph.\n\n"] * 4
+
+        chunks = worker.chunk_data_by_paragraph_by_characters(data, chunk_size=35, overlap=0)
+
+        self.assertEqual(len(chunks), 4)
+        self.assertEqual(type(chunks[0]), dict)
+
+    def test_chunk_paragraph_by_characters_overlap(self):
+        data = ["This is an example paragraph.\n\n"] * 2
+
+        chunks = worker.chunk_data_by_paragraph_by_characters(data, chunk_size=35, overlap=15)
+
+        expected_overlap = 'This is an exam'
+        self.assertEqual(chunks[0]['text'][:15], expected_overlap)
+        self.assertEqual(type(chunks[0]), dict)
+
+    def test_chunk_paragraph_by_characters_bound(self):
+        data = ["This is \n\n a very early paragraph."]
+
+        chunks = worker.chunk_data_by_paragraph_by_characters(data, chunk_size=35, overlap=0, bound=0.75)
+
+        self.assertEqual(len(chunks), 1)
+        self.assertEqual(type(chunks[0]), dict)
+
+    def test_chunk_sentence_by_characters_too_big(self):
+        data = ["I am a sentence. I am a sentence but with a question? I am still a sentence! Can I consider myself a sentence... Blahblah Blahblah Blahblah Blahblah Blahblah Blahblah ."]
+
+        chunks = worker.chunk_by_sentence_by_characters(data, chunk_size=50, overlap=0)
+
+        self.assertEqual(len(chunks), 6)
+        self.assertEqual(type(chunks[0]), dict)
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/worker/worker.py
+++ b/src/worker/worker.py
@@ -234,6 +234,17 @@ def chunk_data_exact(data_chunks, chunk_size, chunk_overlap):
 
     return chunks
 
+def chunk_data_exact_by_characters(data_chunks, chunk_size, chunk_overlap):
+    data = "".join(data_chunks)
+    chunks = []
+    for i in range(0, len(data), chunk_size - chunk_overlap):
+        text = data[i:i + chunk_size]
+        chunk_id = generate_uuid_from_tuple((text, i, "exact"))
+        chunk = {'text': text, 'chunk_id': chunk_id}
+        chunks.append(chunk)
+    
+    return chunks
+
 # TODO: this splits by two new lines - '\n\n' - but it should also account for paragraphs split by one - '\n
 def chunk_data_by_paragraph(data_chunks, chunk_size, overlap, bound=0.75):
     data = "".join(data_chunks)


### PR DESCRIPTION
## WHAT
Added character based chunking methods back into the worker. Added corresponding chunking strategies. Altered original methods to output dictionaries instead of lists. Altered unit tests to check that chunks are dictionaries. 

## Verification
Shows that the client runs and completes jobs for the three new chunking strategies. (In the order exact_by_characters, paragraph_by_characters, sentences_by_characters)

![Screenshot 2023-10-20 171218](https://github.com/dgarnitz/vectorflow/assets/131202513/39d27604-e90d-4e88-b241-f5f95cd221cd)

![Screenshot 2023-10-20 171246](https://github.com/dgarnitz/vectorflow/assets/131202513/42791b87-103e-4983-8116-f9d39b4a3124)

![Screenshot 2023-10-20 171306](https://github.com/dgarnitz/vectorflow/assets/131202513/78a45d5d-4231-4cdd-9067-8d8f0496d99f)

Below shows that all unittests pass:

![Screenshot 2023-10-20 171340](https://github.com/dgarnitz/vectorflow/assets/131202513/d705ba75-603a-4392-a102-f77c9d37064b)

