### PR TITLE
made VF client compatible with llama index implementation

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -60,3 +60,32 @@ vectorflow.vector_db.vector_db_type = VectorDBType.PINECONE
 vectorflow.vector_db.environment = "us-east-1-aws"
 vectorflow.vector_db.index_name = "test"
 ```
+
+## Chunk Enhancer
+The VectorFlow Client also features a RAG chunk enhancer. It works by passing it a list of chunks, the original source document and a use case describing the kind of searches you will run. It then adds extra relevant contextual information to the end of each chunk based on the use case to help facilitate better similarity searches. 
+
+### Usage
+
+```
+from vectorflow_client.chunk_enhancer import ChunkEnhancer
+import fitz
+
+usecase = """
+I am reviewing academic papers about search and evaluation techniques for large language models to try to utilize them more effectively.
+I want to supplement my existing knowledge with state of the art techniques and see if I can apply them to my own work.
+I will want to compare and contrast different techniques.
+I will also want to learn about the detail technical workings of these, including at a mathematical level.
+The purpose of this sytem is to help me while conducting both research and building real world applications using large language models.
+"""
+
+enhancer = ChunkEnhancer(usecase=usecase, openai_api_key="your-key")
+
+doc = fitz.open("paper.pdf")
+pdf_text = ""
+for page in doc:
+  pdf_text += page.get_text()
+
+chunk1 = pdf_text[:2048]
+chunks = [chunk1]
+enhanced_chunks = enhancer.enhance_chunks(chunks, pdf_text)
+```

--- a/client/pyproject.toml
+++ b/client/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "vectorflow_client"
-version = "0.0.7"
+version = "0.0.8"
 authors = [
   { name="David Garnitz", email="david@getvectorflow.com" },
 ]

--- a/client/pyproject.toml
+++ b/client/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "vectorflow_client"
-version = "0.0.8"
+version = "0.0.9"
 authors = [
   { name="David Garnitz", email="david@getvectorflow.com" },
 ]

--- a/client/src/vectorflow_client/vectorflow.py
+++ b/client/src/vectorflow_client/vectorflow.py
@@ -26,6 +26,7 @@ class Vectorflow:
         self.vector_db_key = vector_db_key
         self.embeddings_api_key = embedding_api_key
         self.internal_api_key = internal_api_key
+        self.base_url = "http://localhost:8000"
 
     def serialize(self):
         data = {
@@ -38,8 +39,8 @@ class Vectorflow:
         }
         return {k: v for k, v in data.items() if v is not None}
 
-    def upload(self, file_paths: list[str], base_url: str = "http://localhost:8000"):
-        url = base_url + "/jobs"
+    def upload(self, file_paths: list[str]):
+        url = self.base_url + "/jobs"
         data = self.serialize()
         headers = self.generate_headers()
         multipart_form_data = [('file', (os.path.basename(filepath), open(filepath, 'rb'), 'application/octet-stream')) for filepath in file_paths]
@@ -57,8 +58,8 @@ class Vectorflow:
 
         return Response.from_json(response_json, response.status_code)
     
-    def get_job_statuses(self, job_ids: list[int], base_url: str = "http://localhost:8000"):
-        url = base_url + "/jobs/status"
+    def get_job_statuses(self, job_ids: list[int]):
+        url = self.base_url + "/jobs/status"
         headers = {
             "Authorization": self.internal_api_key,
         }
@@ -80,8 +81,8 @@ class Vectorflow:
 
         return Response.from_json(response_json, response.status_code)
     
-    def embed(self, filepath, base_url: str = "http://localhost:8000"):
-        url = base_url + "/embed"
+    def embed(self, filepath):
+        url = self.base_url + "/embed"
         data = self.serialize()
         headers = self.generate_headers()
 
@@ -102,8 +103,8 @@ class Vectorflow:
 
         return Response.from_json(response_json, response.status_code)
 
-    def get_job_status(self, job_id, base_url: str = "http://localhost:8000"):
-        url = base_url + "/jobs/" + str(job_id) + "/status"
+    def get_job_status(self, job_id):
+        url = self.base_url + "/jobs/" + str(job_id) + "/status"
         headers = {
             "Authorization": self.internal_api_key,
         }

--- a/client/src/vectorflow_client/vectorflow.py
+++ b/client/src/vectorflow_client/vectorflow.py
@@ -39,8 +39,12 @@ class Vectorflow:
         }
         return {k: v for k, v in data.items() if v is not None}
 
-    def upload(self, file_paths: list[str]):
-        url = self.base_url + "/jobs"
+    def upload(self, file_paths: list[str], base_url=None):
+        if base_url:
+            url = base_url + "/jobs"
+        else:
+            url = self.base_url + "/jobs"
+        
         data = self.serialize()
         headers = self.generate_headers()
         multipart_form_data = [('file', (os.path.basename(filepath), open(filepath, 'rb'), 'application/octet-stream')) for filepath in file_paths]
@@ -58,8 +62,12 @@ class Vectorflow:
 
         return Response.from_json(response_json, response.status_code)
     
-    def get_job_statuses(self, job_ids: list[int]):
-        url = self.base_url + "/jobs/status"
+    def get_job_statuses(self, job_ids: list[int], base_url=None):
+        if base_url:
+            url = base_url + "/jobs/status"
+        else:
+            url = self.base_url + "/jobs/status"
+        
         headers = {
             "Authorization": self.internal_api_key,
         }
@@ -81,8 +89,12 @@ class Vectorflow:
 
         return Response.from_json(response_json, response.status_code)
     
-    def embed(self, filepath):
-        url = self.base_url + "/embed"
+    def embed(self, filepath, base_url=None):
+        if base_url:
+            url = base_url + "/embed"
+        else:
+            url = self.base_url + "/embed"
+        
         data = self.serialize()
         headers = self.generate_headers()
 
@@ -103,8 +115,12 @@ class Vectorflow:
 
         return Response.from_json(response_json, response.status_code)
 
-    def get_job_status(self, job_id):
-        url = self.base_url + "/jobs/" + str(job_id) + "/status"
+    def get_job_status(self, job_id, base_url=None):
+        if base_url:
+            url = base_url + "/jobs/" + str(job_id) + "/status"
+        else:
+            url = self.base_url + "/jobs/" + str(job_id) + "/status"
+        
         headers = {
             "Authorization": self.internal_api_key,
         }


### PR DESCRIPTION
## What
Altered the VectorFlow client so that the `base_url` is now a property on the `Vectorflow` class rather than a parameter in each method. This makes it compatible with the Llama Index implementation

## Verification
Works locally:

<img width="1342" alt="image" src="https://github.com/dgarnitz/vectorflow/assets/126617947/6d009850-cb2a-4705-af1a-dd9b6c05ef1d">

Works in colab:

<img width="1062" alt="image" src="https://github.com/dgarnitz/vectorflow/assets/126617947/d1c91c8a-20ce-4344-85a2-a83f707962e0">
