### PR TITLE
fixed qdrant error

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ docker-compose build --no-cache
 docker-compose up -d
 ```
 
-Note that the `init` containers are running a script that sets up the database schema, vector DB and Min.io object store. These containers stop after the script completes.
+Note that the `init` containers are running a script that sets up the database schema, vector DB and Min.io object store. These containers stop after the script completes. For qdrant, make sure to pull version 1.9.1 since that is the version the qdrant client python package is supposed to work with. 
 
 
 ## Using VectorFlow
@@ -346,3 +346,9 @@ where `match`` objects are defined as:
     "metadata": {"source_document" : str}
 }
 ```
+
+### Building the Individual Images with Docker Commands
+If you want to use `docker build` and `docker run` to build and run individual images instead of `docker-compose` follow these steps:
+1. `cd src/`
+2. `docker build --file api/Dockerfile -t vectorflow_api:latest .` to build - don't forget the period at the end
+3. `docker run --network=vectorflow --name=vectorflow_api -d --env-file=../env_scripts/env_vars.env -p 8000:8000 vectorflow_api:latest` to run the api. you don't need the port argument to run the worker

--- a/src/worker/requirements.txt
+++ b/src/worker/requirements.txt
@@ -52,7 +52,7 @@ python-dateutil==2.8.2
 python-dotenv==1.0.0
 pytz==2023.3
 PyYAML==6.0.1
-qdrant-client==1.4.0
+qdrant-client==1.9.1
 ratelimiter==1.2.0.post0
 regex==2023.10.3
 requests==2.31.0


### PR DESCRIPTION
## What
The qdrant client was throwing an error because it was pegged to version 1.5.3 when the newest version of qdrant is 1.9.1

We need to version the command to pull the qdrant image next. 